### PR TITLE
fix: correct maintainer URL for Tsuyoshi Otake

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,7 +27,7 @@ We, at SystemEXE, promise to solve challenges together with all stakeholders, en
 
 ## Maintainers
 
-[![Maintainer: @tsuyoshi-otake](https://img.shields.io/badge/Maintainer-@tsuyoshi--otake-green)](https://github.com/tsuyoshi-otake-system-exe-jp)
+[![Maintainer: @tsuyoshi-otake](https://img.shields.io/badge/Maintainer-@tsuyoshi--otake-green)](https://github.com/tsuyoshi-otake)
 [![Maintainer: @fumiaki-motoyoshi](https://img.shields.io/badge/Maintainer-@fumiaki--motoyoshi-green)](https://github.com/fumiaki-motoyoshi-system-exe-jp)
 
 For more information, visit our [SystemEXE](https://www.system-exe.co.jp/).


### PR DESCRIPTION
Updated the GitHub URL for maintainer Tsuyoshi Otake from tsuyoshi-otake-system-exe-jp to tsuyoshi-otake as requested.

Fixes #1